### PR TITLE
Remove selected value when touch is terminated, also added callback

### DIFF
--- a/docusaurus/docs/line.md
+++ b/docusaurus/docs/line.md
@@ -17,6 +17,7 @@ This component draws a line. Multiple lines can be drawn on one chart.
 | `tension`      | `number` | No | Only works in combination with smoothing = `bezier`. Value between 0 and 1, recommended somewhere around `0.3`. |
 | `tooltipComponent`   | `JSX.Element` | No | Component to be used to draw tooltips. This library provides a basic tooltip with the `Tooltip` component. Example below.  |
 | `onTooltipSelect`   | `(value: { x: number, y: number, meta?: any }, index: number) => void` | No | Callback method that fires when a tooltip is displayed for a data point.  |
+| `onTooltipSelectEnd`   | `() => void` | No | Callback method that fires when the user stopped touching the chart.  |
 | `theme`   | Defined below        | No | Theme for the line.  |
 
 \* unless provided in parent `<Chart />` component

--- a/src/Chart.tsx
+++ b/src/Chart.tsx
@@ -60,6 +60,10 @@ const Chart: React.FC<Props> = (props) => {
         x: clamp(evt.nativeEvent.x - padding.left, 0, dataDimensions.width),
         y: clamp(evt.nativeEvent.y - padding.top, 0, dataDimensions.height),
       })
+
+      if (evt.nativeEvent.state === State.END) {
+        setLastTouch(undefined);
+      }
     }
 
     return true

--- a/src/Chart.tsx
+++ b/src/Chart.tsx
@@ -60,10 +60,6 @@ const Chart: React.FC<Props> = (props) => {
         x: clamp(evt.nativeEvent.x - padding.left, 0, dataDimensions.width),
         y: clamp(evt.nativeEvent.y - padding.top, 0, dataDimensions.height),
       })
-
-      if (evt.nativeEvent.state === State.END) {
-        setLastTouch(undefined);
-      }
     }
 
     return true
@@ -82,6 +78,7 @@ const Chart: React.FC<Props> = (props) => {
       if (evt.nativeEvent.state === State.END) {
         offset.x.setValue(clamp((offset.x as any)._value - evt.nativeEvent.translationX * factorX, xDomain.min, xDomain.max - viewport.size.width))
         offset.y.setValue(clamp((offset.y as any)._value + evt.nativeEvent.translationY * factorY, yDomain.min, yDomain.max - viewport.size.height))
+        setLastTouch(undefined);
       }
     }
     return true

--- a/src/Line.tsx
+++ b/src/Line.tsx
@@ -23,6 +23,8 @@ type Props = {
   tooltipComponent?: JSX.Element
   /** Callback method that fires when a tooltip is displayed for a data point. */
   onTooltipSelect?: (value: ChartDataPoint, index: number) => void
+  /** Callback method that fires when the user stoped touching the chart. */
+  onTooltipSelectEnd?: () => void
   /** Data for the chart. Overrides optional data provided in `<Chart />`. */
   data?: ChartDataPoint[]
 }
@@ -38,6 +40,7 @@ const Line: React.FC<Props> = (props) => {
     tension,
     smoothing,
     onTooltipSelect,
+    onTooltipSelectEnd = () => {},
   } = deepmerge(defaultProps, props)
 
   if (!dimensions) {
@@ -47,6 +50,10 @@ const Line: React.FC<Props> = (props) => {
   React.useEffect(() => {
     const scaledPoints = scalePointsToDimensions(data, viewportDomain, dimensions)
     const newIndex = calculateTooltipIndex(scaledPoints, lastTouch)
+
+    if (tooltipIndex !== undefined && newIndex === undefined && !lastTouch) {
+      onTooltipSelectEnd()
+    }
 
     if (newIndex !== tooltipIndex) {
       setTooltipIndex(newIndex)

--- a/src/Line.tsx
+++ b/src/Line.tsx
@@ -23,7 +23,7 @@ type Props = {
   tooltipComponent?: JSX.Element
   /** Callback method that fires when a tooltip is displayed for a data point. */
   onTooltipSelect?: (value: ChartDataPoint, index: number) => void
-  /** Callback method that fires when the user stoped touching the chart. */
+  /** Callback method that fires when the user stopped touching the chart. */
   onTooltipSelectEnd?: () => void
   /** Data for the chart. Overrides optional data provided in `<Chart />`. */
   data?: ChartDataPoint[]


### PR DESCRIPTION
Hey! first of all thanks for this repo very easy to work and very well documented!

This is merely a suggestion,
Currently when touch is starting the last selected data point gets recorded and never disappears, This removes it when the touch is terminated.

Also in my case I used the selected tooltip data to change the displayed data in **other component**, so the `onTooltipSelectEnd` callback is being used to restore the original state (of the other component) 