### PR TITLE
Support fontFamily for labels

### DIFF
--- a/demo/ios/Podfile.lock
+++ b/demo/ios/Podfile.lock
@@ -296,8 +296,8 @@ PODS:
     - React-Core (= 0.63.3)
     - React-cxxreact (= 0.63.3)
     - React-jsi (= 0.63.3)
-  - RNGestureHandler (1.8.0):
-    - React
+  - RNGestureHandler (1.9.0):
+    - React-Core
   - RNSVG (12.1.0):
     - React
   - Yoga (1.14.0)
@@ -465,7 +465,7 @@ SPEC CHECKSUMS:
   React-RCTText: 65a6de06a7389098ce24340d1d3556015c38f746
   React-RCTVibration: 8e9fb25724a0805107fc1acc9075e26f814df454
   ReactCommon: 4167844018c9ed375cc01a843e9ee564399e53c3
-  RNGestureHandler: 7a5833d0f788dbd107fbb913e09aa0c1ff333c39
+  RNGestureHandler: 9b7e605a741412e20e13c512738a31bd1611759b
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/src/HorizontalAxis.tsx
+++ b/src/HorizontalAxis.tsx
@@ -107,6 +107,7 @@ const HorizontalAxis: React.FC<Props> = (props) => {
                 <Text
                   fontSize={labels.label.fontSize}
                   fontWeight={labels.label.fontWeight}
+                  fontFamily={labels.label.fontFamily}
                   fill={labels.label.color}
                   opacity={labels.label.opacity}
                   textAnchor={labels.label.textAnchor}

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -43,6 +43,7 @@ const Tooltip: React.FC<Props> = (props) => {
         y={position.y - label.dy}
         fontSize={label.fontSize}
         fontWeight={label.fontWeight}
+        fontFamily={label.fontFamily}
         fill={label.color}
         opacity={label.opacity}
         textAnchor={label.textAnchor}

--- a/src/VerticalAxis.tsx
+++ b/src/VerticalAxis.tsx
@@ -102,6 +102,7 @@ const VerticalAxis: React.FC<Props> = (props) => {
                 <Text
                   fontSize={labels.label.fontSize}
                   fontWeight={labels.label.fontWeight}
+                  fontFamily={labels.label.fontFamily}
                   fill={labels.label.color}
                   opacity={labels.label.opacity}
                   textAnchor={labels.label.textAnchor}

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export type TextAnchor = 'start' | 'middle' | 'end'
 export type Label = {
   color?: string
   fontSize?: number
+  fontFamily?: string
   opacity?: number
   dy?: number
   dx?: number


### PR DESCRIPTION
Made fontFamily prop available in label config to use in underlying react-native-svg text component.